### PR TITLE
DotNetCore compatability - CryptoConfig.CreateFromName() missing in Core

### DIFF
--- a/TwoFactorAuth.Net/TwoFactorAuth.cs
+++ b/TwoFactorAuth.Net/TwoFactorAuth.cs
@@ -235,9 +235,8 @@ namespace TwoFactorAuthNet
         /// <returns>Returns a TOTP code based on the specified secret for the specified timestamp.</returns>
         public string GetCode(string secret, long timestamp)
         {
-            using (var algo = KeyedHashAlgorithm.Create("HMAC" + Enum.GetName(typeof(Algorithm), Algorithm)))
+            using (var algo = (KeyedHashAlgorithm)CryptoConfig.CreateFromName("HMAC" + Enum.GetName(typeof(Algorithm), Algorithm)))
             {
-
                 algo.Key = Base32.Decode(secret);
                 var ts = BitConverter.GetBytes(GetTimeSlice(timestamp, 0));
                 var hashhmac = algo.ComputeHash(new byte[] { 0, 0, 0, 0, ts[3], ts[2], ts[1], ts[0] });


### PR DESCRIPTION
Thank you for creating this library.  I got it working in my .Net Core project by making this change.

Apparently there's a function in Framework that's missing in Core.  There is a bug report about it here: https://github.com/dotnet/corefx/issues/22626

Within the .NET library it's a one line function that does exactly this, so I'd say there's no risk or performance issues.