### PR TITLE
Make GetQrText method public

### DIFF
--- a/TwoFactorAuth.Net.Tests/TwoFactorAuthTests.cs
+++ b/TwoFactorAuth.Net.Tests/TwoFactorAuthTests.cs
@@ -168,6 +168,14 @@ namespace TwoFactorAuthNet.Tests
         [TestMethod]
         public void VerifyTotpUriIsCorrect()
         {
+            var target = new TwoFactorAuth(issuer: "Test&Issuer");
+            var data = target.GetQrText("Test&Label", "VMR466AB62ZBOKHE");
+            Assert.AreEqual("otpauth://totp/Test%26Label?secret=VMR466AB62ZBOKHE&issuer=Test%26Issuer&period=30&algorithm=SHA1&digits=6", data);
+        }
+        
+        [TestMethod]
+        public void VerifyTotpUriInQrCodeIsCorrect()
+        {
             var qr = new TestQrProvider();
             var target = new TwoFactorAuth(issuer: "Test&Issuer", qrcodeprovider: qr);
 

--- a/TwoFactorAuth.Net/TwoFactorAuth.cs
+++ b/TwoFactorAuth.Net/TwoFactorAuth.cs
@@ -539,7 +539,7 @@ namespace TwoFactorAuthNet
         /// <param name="label">The label for the TOTP Uri.</param>
         /// <param name="secret">The secret for the TOTP Uri.</param>
         /// <returns>Returns a TOTP Uri with specified label and secret.</returns>
-        private string GetQrText(string label, string secret)
+        public string GetQrText(string label, string secret)
         {
             var x = "otpauth://totp/" + Uri.EscapeDataString(label)
                 + "?secret=" + Uri.EscapeDataString(secret)


### PR DESCRIPTION
While trying to use this library in our ecosystem I need the raw data of the qrcode instead of an image. This change allows me to do this without manual building the data string.